### PR TITLE
Various bug fixes + Vue 3 TypeScript support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-autoimport",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         /* Strict Type-Checking Option */
         "strict": true,   /* enable all strict type-checking options */
         /* Additional Checks */
+        "noImplicitAny": false,
         "noUnusedLocals": true /* Report errors on unused locals. */
         // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
         // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
         /* Strict Type-Checking Option */
         "strict": true,   /* enable all strict type-checking options */
         /* Additional Checks */
-        "noImplicitAny": false,
         "noUnusedLocals": true /* Report errors on unused locals. */
         // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
         // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
### Changes:
- added support for the Vue 3 TypeScript syntax using `defineComponent()`
- **fixed:** extension doesn't indent the `import` statement even with the **Indent Script Tag** option enabled
- **fixed:** leaves empty new line after the `components` object with **Insert One Component Per Line** enabled
- **fixed:** doesn't add comma after the `components` object when **Has Trailing Comma** is disabled
  - now it adds comma when there are other properties in the component's object *(e.g. **computed**, **methods**,...)*

<br>

Hope that covers about all of the changes. Basically I tried to cover all the edge cases that were causing broken formatting. (Oh and some of the minor formatting changes to the code were not done by me but by running the `npm run format` command.)